### PR TITLE
feat: Support for mrpack format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add `<OUTPUT>` argument to `build` command
+
+  - `instance` builds the project into a usable Minecraft instance
+  - `modrinth` builds the project into a [mrpack format](https://docs.modrinth.com/docs/modpacks/format_definition/) used by [Modrinth](https://modrinth.com/)
+
 - Rename `installation` to `instance`
 
 ## [0.1.0-rc.1] - 2023-05-13

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ niter add <MOD> # Adds a new mod to the current project
 Build the project:
 
 ```sh
-niter build # Builds the current project
+niter build instance # Builds the current project into a usable instance
 ```
 
 Your modpack is now available under `build/instance`.

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -33,9 +33,7 @@ impl Output {
         let sources = project.build_sources()?;
 
         match self {
-            Output::Instance => {
-                ops::build_instance(sources, path.as_ref().join("instance"))
-            }
+            Output::Instance => ops::build_instance(sources, path.as_ref().join("instance")),
             Output::Modrinth => {
                 ops::build_modrinth(&project.manifest, sources, path.as_ref().join("modrinth"))
             }

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,18 +1,44 @@
 use crate::ops;
 use crate::Project;
+use clap::ValueEnum;
 use log::info;
 use std::env;
+use std::path::Path;
 
 #[derive(clap::Args)]
-pub struct BuildArgs;
+pub struct BuildArgs {
+    output: Output,
+}
+
+#[derive(Debug, Clone, ValueEnum)]
+enum Output {
+    Instance,
+    Modrinth,
+}
 
 impl BuildArgs {
     pub fn run(&self) -> eyre::Result<()> {
         let current_dir = env::current_dir().unwrap();
+        let project = Project::read(&current_dir)?;
 
-        ops::build(&Project::read(&current_dir)?, current_dir.join("build"))?;
+        self.output.build(current_dir.join("build"), &project)?;
 
         info!("Finished building modpack");
         Ok(())
+    }
+}
+
+impl Output {
+    pub fn build<P: AsRef<Path>>(&self, path: P, project: &Project) -> eyre::Result<()> {
+        let sources = project.build_sources()?;
+
+        match self {
+            Output::Instance => {
+                ops::build_instance(sources, path.as_ref().join("instance"))
+            }
+            Output::Modrinth => {
+                ops::build_modrinth(&project.manifest, sources, path.as_ref().join("modrinth"))
+            }
+        }
     }
 }

--- a/src/ops/build.rs
+++ b/src/ops/build.rs
@@ -1,5 +1,6 @@
 use crate::source::BuildSource;
-use crate::Project;
+use crate::util::mrpack;
+use crate::{Manifest, Project};
 use eyre::{Result, WrapErr};
 use log::info;
 use std::fs;
@@ -37,6 +38,12 @@ pub fn build_instance(sources: Vec<BuildSource>, path: PathBuf) -> Result<()> {
     }
 
     Ok(())
+}
+
+pub fn build_modrinth(manifest: &Manifest, sources: Vec<BuildSource>, path: PathBuf) -> Result<()> {
+    fs::create_dir_all(&path).wrap_err("failed to create modrinth directory")?;
+
+    mrpack::write_index(path.join("modrinth.index.json"), manifest, sources)
 }
 
 fn download(client: &reqwest::blocking::Client, path: &Path, url: &str) -> Result<()> {

--- a/src/source.rs
+++ b/src/source.rs
@@ -13,10 +13,13 @@ pub enum Source {
     Modrinth { version: String },
 }
 
+#[derive(Debug, Clone)]
 pub struct BuildSource {
     pub name: String,
     pub url: String,
     pub file: String,
+    pub sha1: String,
+    pub sha512: String,
 }
 
 impl BuildSource {
@@ -31,6 +34,8 @@ impl BuildSource {
                     .map(|s| s.into())
                     .wrap_err("invalid url")?,
                 url: url.to_string(),
+                sha1: todo!(),
+                sha512: todo!(),
             },
             Source::Modrinth { version } => {
                 let version = match modrinth::version(version) {
@@ -50,6 +55,8 @@ impl BuildSource {
                     name: mod_data.name.to_string(),
                     url: file.url.to_string(),
                     file: file.filename.to_string(),
+                    sha1: file.hashes.sha1.to_string(),
+                    sha512: file.hashes.sha512.to_string(),
                 }
             }
         })

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,1 +1,2 @@
 pub mod modrinth;
+pub mod mrpack;

--- a/src/util/modrinth/mod.rs
+++ b/src/util/modrinth/mod.rs
@@ -33,11 +33,11 @@ pub struct VersionFile {
     pub url: String,
     pub filename: String,
     pub primary: bool,
-    pub hashes: ModrinthVersionFileHashes,
+    pub hashes: Hashes,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModrinthVersionFileHashes {
+pub struct Hashes {
     pub sha512: String,
     pub sha1: String,
 }

--- a/src/util/modrinth/mod.rs
+++ b/src/util/modrinth/mod.rs
@@ -33,6 +33,13 @@ pub struct ModrinthVersionFile {
     pub url: String,
     pub filename: String,
     pub primary: bool,
+    pub hashes: ModrinthVersionFileHashes,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModrinthVersionFileHashes {
+    pub sha512: String,
+    pub sha1: String,
 }
 
 impl ModrinthVersion {

--- a/src/util/mrpack/mod.rs
+++ b/src/util/mrpack/mod.rs
@@ -1,0 +1,182 @@
+use std::{fs, path::Path};
+
+use eyre::Result;
+use serde::{Deserialize, Serialize};
+
+use crate::{source::BuildSource, Manifest};
+
+pub fn write_index<P: AsRef<Path>>(
+    path: P,
+    manifest: &Manifest,
+    sources: Vec<BuildSource>,
+) -> Result<()> {
+    let index = Index::from_project(manifest, sources);
+    let string = serde_json::to_string(&index)?;
+    fs::write(path, string)?;
+    Ok(())
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Index {
+    #[serde(rename = "formatVersion")]
+    format: i32,
+    game: Game,
+
+    name: String,
+
+    #[serde(rename = "versionId")]
+    version: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    summary: Option<String>,
+
+    files: Vec<File>,
+    dependencies: Dependencies,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Game {
+    Minecraft,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct File {
+    path: String,
+    hashes: Hashes,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "env")]
+    environments: Option<Environments>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Hashes {
+    sha1: String,
+    sha512: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Environments {
+    client: EnvironmentSupport,
+    server: EnvironmentSupport,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum EnvironmentSupport {
+    Required,
+    Optional,
+    Unsupported,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct Dependencies {
+    minecraft: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    forge: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "fabric-loader")]
+    fabric: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "quilt-loader")]
+    quilt: Option<String>,
+}
+
+impl Index {
+    pub fn new(
+        name: String,
+        version: String,
+        summary: Option<String>,
+        files: Vec<File>,
+        dependencies: Dependencies,
+    ) -> Self {
+        Self {
+            format: 1,
+            game: Game::Minecraft,
+
+            name,
+            version,
+            summary,
+            files,
+            dependencies,
+        }
+    }
+
+    pub fn from_project(manifest: &Manifest, sources: Vec<BuildSource>) -> Self {
+        Self::new(
+            manifest.name.clone(),
+            manifest.version.clone(),
+            None,
+            sources
+                .iter()
+                .map(|source| source.to_owned().into())
+                .collect(),
+            todo!(),
+        )
+    }
+}
+
+impl File {
+    pub fn new(path: String, hashes: Hashes, environments: Option<Environments>) -> Self {
+        Self {
+            path,
+            hashes,
+            environments,
+        }
+    }
+}
+
+impl From<BuildSource> for File {
+    fn from(value: BuildSource) -> Self {
+        Self::new(
+            format!("mods/{}", value.file),
+            Hashes::new(value.sha1, value.sha512),
+            None,
+        )
+    }
+}
+
+impl Hashes {
+    pub fn new(sha1: String, sha512: String) -> Self {
+        Self { sha1, sha512 }
+    }
+}
+
+impl Default for Game {
+    fn default() -> Self {
+        Self::Minecraft
+    }
+}
+
+impl Dependencies {
+    pub fn forge(minecraft: String, forge: String) -> Self {
+        Self {
+            minecraft,
+            forge: Some(forge),
+            fabric: None,
+            quilt: None,
+        }
+    }
+
+    pub fn fabric(minecraft: String, fabric: String) -> Self {
+        Self {
+            minecraft,
+            forge: None,
+            fabric: Some(fabric),
+            quilt: None,
+        }
+    }
+
+    pub fn quilt(minecraft: String, quilt: String) -> Self {
+        Self {
+            minecraft,
+            forge: None,
+            fabric: None,
+            quilt: Some(quilt),
+        }
+    }
+}


### PR DESCRIPTION
Adds support for [the mrpack format](https://docs.modrinth.com/docs/modpacks/format_definition/) used by [Modrinth](https://modrinth.com/) for publishing and downloading modpacks.

### Tasks

  - [x] Create structs for serializing index file
  - [x] Add output argument to build command
  - [ ] Add conversion from Project struct to Index
  
    - [ ] Build source conversion
    - [ ] Dependencies conversion
  
  - [ ] Document build command