### PR TITLE
feat: Add a directory for configuration files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add a `config` directory that contains mod configurations
+
+  - This directory is included in builds
+
 - Rename `installation` to `instance`
 
 ## [0.1.0-rc.1] - 2023-05-13

--- a/example/config/jei/jei-client.ini
+++ b/example/config/jei/jei-client.ini
@@ -1,0 +1,5 @@
+[advanced]
+	# Description: Display search bar in the center
+	# Valid Values: [true, false]
+	# Default Value: false
+	CenterSearch = true

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -10,7 +10,7 @@ impl InitArgs {
     pub fn run(&self) -> eyre::Result<()> {
         let current_dir = env::current_dir().unwrap();
 
-        let project = Project::new(Manifest::new(
+        let project = Project::from(Manifest::new(
             current_dir
                 .file_name()
                 .and_then(|name| name.to_os_string().into_string().ok())

--- a/src/ops/build.rs
+++ b/src/ops/build.rs
@@ -25,9 +25,6 @@ pub fn build_instance(project: &Project, sources: Vec<BuildSource>, path: PathBu
     if let Some(project_config) = &project.config_dir {
         let config_dir = path.join("config");
 
-        fs::create_dir(&config_dir)
-            .wrap_err("failed to create config directory inside instance")?;
-
         copy_recursive(project_config, config_dir).wrap_err("failed to copy config files")?;
     }
 
@@ -60,6 +57,8 @@ fn download(client: &reqwest::blocking::Client, path: &Path, url: &str) -> Resul
 }
 
 fn copy_recursive<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> Result<()> {
+    fs::create_dir(&to)?;
+
     for entry in fs::read_dir(from)? {
         let entry = entry?;
         let path = entry.path();
@@ -69,5 +68,6 @@ fn copy_recursive<U: AsRef<Path>, V: AsRef<Path>>(from: U, to: V) -> Result<()> 
             fs::copy(path, to.as_ref().join(entry.file_name()))?;
         }
     }
+
     Ok(())
 }

--- a/src/project.rs
+++ b/src/project.rs
@@ -1,7 +1,7 @@
 use crate::source::BuildSource;
 use crate::{Manifest, Source};
 use eyre::Result;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone)]
 pub struct Mod {
@@ -14,6 +14,7 @@ pub struct Mod {
 pub struct Project {
     pub manifest: Manifest,
     pub mods: Vec<Mod>,
+    pub config_dir: Option<PathBuf>,
 }
 
 impl Mod {
@@ -27,12 +28,12 @@ impl Mod {
 }
 
 impl Project {
-    pub fn new(manifest: Manifest) -> Self {
-        Self::with_mods(manifest, vec![])
-    }
-
-    pub fn with_mods(manifest: Manifest, mods: Vec<Mod>) -> Self {
-        Project { manifest, mods }
+    pub fn new(manifest: Manifest, mods: Vec<Mod>, config_dir: Option<PathBuf>) -> Self {
+        Self {
+            manifest,
+            mods,
+            config_dir,
+        }
     }
 
     pub fn read<P: AsRef<Path>>(path: P) -> Result<Self> {
@@ -57,6 +58,7 @@ impl From<Manifest> for Project {
         Project {
             manifest: value,
             mods: vec![],
+            config_dir: None,
         }
     }
 }

--- a/src/toml/mod.rs
+++ b/src/toml/mod.rs
@@ -11,7 +11,7 @@ pub fn read_project<P: AsRef<Path>>(path: P) -> Result<Project> {
     let mods =
         read_mods(path.as_ref().join_mods_dir()).wrap_err("failed to read mods directory")?;
 
-    Ok(Project::with_mods(manifest, mods))
+    Ok(Project::new(manifest, mods, None))
 }
 
 pub fn read_manifest<P: AsRef<Path>>(path: P) -> Result<Manifest> {
@@ -134,7 +134,7 @@ impl From<Manifest> for TomlManifest {
 
 impl From<TomlManifest> for Project {
     fn from(value: TomlManifest) -> Self {
-        Project::new(value.into())
+        Project::from(Manifest::from(value))
     }
 }
 

--- a/src/toml/mod.rs
+++ b/src/toml/mod.rs
@@ -10,8 +10,15 @@ pub fn read_project<P: AsRef<Path>>(path: P) -> Result<Project> {
         .wrap_err("failed to read manifest file")?;
     let mods =
         read_mods(path.as_ref().join_mods_dir()).wrap_err("failed to read mods directory")?;
+    let config_dir = Some(path.as_ref().join_config_dir()).and_then(|path| {
+        if path.exists() && path.is_dir() {
+            Some(path)
+        } else {
+            None
+        }
+    });
 
-    Ok(Project::new(manifest, mods, None))
+    Ok(Project::new(manifest, mods, config_dir))
 }
 
 pub fn read_manifest<P: AsRef<Path>>(path: P) -> Result<Manifest> {
@@ -158,6 +165,7 @@ pub trait JoinToml {
     fn join_manifest_file(&self) -> PathBuf;
     fn join_mods_dir(&self) -> PathBuf;
     fn join_mod_file(&self, name: &str) -> PathBuf;
+    fn join_config_dir(&self) -> PathBuf;
 }
 
 impl JoinToml for Path {
@@ -171,5 +179,9 @@ impl JoinToml for Path {
 
     fn join_mod_file(&self, name: &str) -> PathBuf {
         self.join(name).with_extension("toml")
+    }
+
+    fn join_config_dir(&self) -> PathBuf {
+        self.join("config")
     }
 }


### PR DESCRIPTION
Adds a new `config` directory, which contains configuration for mods.
On instance build, the config directory is copied.